### PR TITLE
Init temp

### DIFF
--- a/aragog/core.py
+++ b/aragog/core.py
@@ -174,9 +174,17 @@ class InitialCondition:
         self._settings: _InitialConditionParameters = self._parameters.initial_condition
 
         if self._settings.from_field:
-            self._temperature = self._settings.init_temperature
+            if (self._mesh.staggered.number_of_nodes == len(self._settings.init_temperature)):
+                self._temperature = self._settings.init_temperature
+            else:
+                msg: str = (
+                        f"the size of the provided init temperature field does not match \
+                    the number of staggered points {self._mesh.staggered.number_of_nodes}"
+                )
+                raise ValueError(msg)
         else:
             self._temperature: np.ndarray = self.get_linear()
+
         logger.debug("initial staggered temperature = %s", self._temperature)
 
     @property

--- a/aragog/core.py
+++ b/aragog/core.py
@@ -172,7 +172,12 @@ class InitialCondition:
 
     def __post_init__(self):
         self._settings: _InitialConditionParameters = self._parameters.initial_condition
-        self._temperature: np.ndarray = self.get_linear()
+
+        if self._settings.from_field:
+            self._temperature = self._settings.init_temperature
+        else:
+            self._temperature: np.ndarray = self.get_linear()
+        logger.debug("initial staggered temperature = %s", self._temperature)
 
     @property
     def temperature(self) -> np.ndarray:

--- a/aragog/parser.py
+++ b/aragog/parser.py
@@ -220,8 +220,15 @@ class _EnergyParameters:
 class _InitialConditionParameters:
     """Stores the settings in the initial_condition section in the configuration data."""
 
-    surface_temperature: float
-    basal_temperature: float
+    surface_temperature: float = 4000
+    basal_temperature: float = 4000
+    init_file: str = None
+    from_field: bool = False
+
+    if (init_file != None):
+        from_field = True
+        init_temperature = np.loadtxt(init_file)
+
     scalings_: _ScalingsParameters = field(init=False)
 
     def scale_attributes(self, scalings: _ScalingsParameters) -> None:
@@ -233,6 +240,8 @@ class _InitialConditionParameters:
         self.scalings_ = scalings
         self.surface_temperature /= self.scalings_.temperature
         self.basal_temperature /= self.scalings_.temperature
+        if self.from_field:
+            self.init_temperature /= self.scalings_.temperature
 
 
 @dataclass

--- a/aragog/parser.py
+++ b/aragog/parser.py
@@ -222,13 +222,8 @@ class _InitialConditionParameters:
 
     surface_temperature: float = 4000
     basal_temperature: float = 4000
-    init_file: str = None
+    init_file: str = ""
     from_field: bool = False
-
-    if (init_file != None):
-        from_field = True
-        init_temperature = np.loadtxt(init_file)
-
     scalings_: _ScalingsParameters = field(init=False)
 
     def scale_attributes(self, scalings: _ScalingsParameters) -> None:
@@ -240,9 +235,11 @@ class _InitialConditionParameters:
         self.scalings_ = scalings
         self.surface_temperature /= self.scalings_.temperature
         self.basal_temperature /= self.scalings_.temperature
-        if self.from_field:
-            self.init_temperature /= self.scalings_.temperature
 
+        if self.init_file:
+            self.from_field = True
+            self.init_temperature = np.loadtxt(self.init_file)
+            self.init_temperature /= self.scalings_.temperature
 
 @dataclass
 class _MeshParameters:


### PR DESCRIPTION
This work adds the possibility to set the whole initial temperature field. You can either specify a file containing the data in the config or you can set it directly through the solver object. The latter will be used in proteus, where we can directly set the temperature field in memory using:

`solver.parameters.initial_condition.from_field = True`
`solver.parameters.initial_condition.init_temperature = temperature`

Where `temperature` is a numpy array containing the scaled staggered temperature field.

I added a check to make sure that the length of the array is consistent with the number of grid points.