### PR TITLE
Write output to NetCDF files

### DIFF
--- a/aragog/output.py
+++ b/aragog/output.py
@@ -204,15 +204,15 @@ class Output:
     def time_range(self) -> float:
         return self.times[-1] - self.times[0]
 
-    def write(self,file_path:str,time_idx:int=-1) -> None:
+    def write_at_time(self,file_path:str,tidx:int=-1) -> None:
         """Write the state of the model at a particular time to a NetCDF4 file on the disk.
 
         Args:
             file_path: Path to the output file.
-            time_idx: Index on the time axis at which to access the data.
+            tidx: Index on the time axis at which to access the data.
         """
 
-        logger.debug(f"Writing i={time_idx} NetCDF file to {file_path}")
+        logger.debug(f"Writing i={tidx} NetCDF file to {file_path}")
 
         # Update the state
         assert self.solution is not None
@@ -232,10 +232,10 @@ class Output:
             ds[key].units = units
 
         # Save scalar quantities
-        _add_scalar_variable("time",        self.times[time_idx],       "yr")
-        _add_scalar_variable("phi_global",  self.melt_fraction_global,  "")
-        _add_scalar_variable("mantle_mass", self.mantle_mass,           "kg")
-        _add_scalar_variable("rheo_front",  self.rheological_front,     "")
+        _add_scalar_variable("time",        self.times[tidx],                "yr")
+        _add_scalar_variable("phi_global",  self.melt_fraction_global[tidx], "")
+        _add_scalar_variable("mantle_mass", self.mantle_mass,                "kg")
+        _add_scalar_variable("rheo_front",  self.rheological_front,          "")
 
         # Create dimensions (just basic nodes for now)
         lev_b = self.shape_basic[0]
@@ -244,7 +244,7 @@ class Output:
         # Function to save vector quantities
         def _add_basic_variable(key:str,property,units:str):
             ds.createVariable(key,np.float64,("basic",), )
-            ds[key][:] = property[:,time_idx]
+            ds[key][:] = property[:,tidx]
             ds[key].units = units
 
         # Save vector quantities

--- a/aragog/output.py
+++ b/aragog/output.py
@@ -225,17 +225,24 @@ class Output:
         ds.description  = "Aragog output data"
         ds.argog_version = __version__
 
-        # Scalar quantities
-        ds.createVariable('time',np.float64)
-        ds["time"][0] = self.times[time_idx]
-        ds["time"].units = "yr"
+        # Function to save scalar quantities
+        def _add_scalar_variable(key:str,value:float,units:str):
+            ds.createVariable(key,np.float64)
+            ds[key][0] = float(value)
+            ds[key].units = units
+
+        # Save scalar quantities
+        _add_scalar_variable("time",        self.times[time_idx],       "yr")
+        _add_scalar_variable("phi_global",  self.melt_fraction_global,  "")
+        _add_scalar_variable("mantle_mass", self.mantle_mass,           "kg")
+        _add_scalar_variable("rheo_front",  self.rheological_front,     "")
 
         # Create dimensions (just basic nodes for now)
         lev_b = self.shape_basic[0]
         ds.createDimension('basic', lev_b)
 
         # Function to save vector quantities
-        def _add_basic_variable(key,property,units):
+        def _add_basic_variable(key:str,property,units:str):
             ds.createVariable(key,np.float64,("basic",), )
             ds[key][:] = property[:,time_idx]
             ds[key].units = units

--- a/aragog/output.py
+++ b/aragog/output.py
@@ -214,6 +214,10 @@ class Output:
 
         logger.debug(f"Writing i={time_idx} NetCDF file to {file_path}")
 
+        # Update the state
+        assert self.solution is not None
+        self.state.update(self.solution.y, self.solution.t)
+
         # Open the dataset
         ds = nc.Dataset(file_path,mode='w')
 
@@ -228,7 +232,7 @@ class Output:
 
         # Create dimensions (just basic nodes for now)
         lev_b = self.shape_basic[0]
-        dim_b = ds.createDimension('basic', lev_b)
+        ds.createDimension('basic', lev_b)
 
         # Function to save vector quantities
         def _add_basic_variable(key,property,units):
@@ -237,11 +241,14 @@ class Output:
             ds[key].units = units
 
         # Save vector quantities
-        _add_basic_variable("radius_b",         self.radii_km_basic,             "km")
-        _add_basic_variable("pressure_b",       self.pressure_GPa_basic,         "GPa")
-        _add_basic_variable("temperature_b",    self.temperature_K_basic,        "K")
-        _add_basic_variable("meltfraction_b",   self.melt_fraction_basic,        "")
-        _add_basic_variable("Fconvect_b",       self.convective_heat_flux_basic, "W m-2")
+        _add_basic_variable("radius_b",     self.radii_km_basic,             "km")
+        _add_basic_variable("pres_b",       self.pressure_GPa_basic,         "GPa")
+        _add_basic_variable("temp_b",       self.temperature_K_basic,        "K")
+        _add_basic_variable("phi_b",        self.melt_fraction_basic,        "")
+        _add_basic_variable("Fconv_b",      self.convective_heat_flux_basic, "W m-2")
+        _add_basic_variable("log10visc_b",  self.log10_viscosity_basic,      "Pa s")
+        _add_basic_variable("density_b",    self.density_basic,              "kg m-3")
+        _add_basic_variable("heatcap_b",    self.heat_capacity_basic,        "J kg-1 K-1")
 
         # Close the dataset
         ds.close()

--- a/aragog/output.py
+++ b/aragog/output.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING
 
 import matplotlib.pyplot as plt
 import numpy as np
+import netCDF4 as nc
 from scipy.optimize import OptimizeResult
 
 from aragog.parser import Parameters
@@ -171,6 +172,15 @@ class Output:
     @property
     def time_range(self) -> float:
         return self.times[-1] - self.times[0]
+    
+    def _write(self,fpath:str) -> None:
+        """Write the output to a file on the disk.
+
+        Args:
+            fpath: Path to the output file.
+        """
+        logger.debug(f"Writing netCDF file to {fpath}")
+
 
     def plot(self, num_lines: int = 11) -> None:
         """Plots the solution with labelled lines according to time.

--- a/aragog/output.py
+++ b/aragog/output.py
@@ -173,13 +173,23 @@ class Output:
     def time_range(self) -> float:
         return self.times[-1] - self.times[0]
     
-    def _write(self,fpath:str) -> None:
-        """Write the output to a file on the disk.
+    def write(self,file_path:str,time_idx:int=-1) -> None:
+        """Write the state of the model at a particular time to a NetCDF4 file on the disk.
 
         Args:
-            fpath: Path to the output file.
+            file_path: Path to the output file.
+            time_idx: Index on the time axis at which to access the data.
         """
-        logger.debug(f"Writing netCDF file to {fpath}")
+
+        logger.debug(f"Writing i={time_idx} NetCDF file to {file_path}")
+
+        # Open the dataset
+        ds = nc.Dataset(file_path)
+
+        
+
+        # Close the dataset
+        ds.close()
 
 
     def plot(self, num_lines: int = 11) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.10,<3.13"
+python = ">=3.10"
 numpy = "^1.26.4"
 scipy = "^1.12.0"
 thermochem = "^0.8.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ packages = [
 python = ">=3.10"
 numpy = "^1.26.4"
 scipy = "^1.12.0"
+netCDF4 = "*"
 thermochem = "^0.8.2"
 matplotlib = "^3.8.3"
 typed-configparser = "^1.1.0"


### PR DESCRIPTION
This PR adds functionality for writing output arrays to NetCDF files. At the moment, this is constructed such that a single file may be written for each point in time using the function `Output.write_at_time()`. Closes #19.

This has been tested inside PROTEUS, where these files are used to generate plots. 