### PR TITLE
Ls/core cooling

### DIFF
--- a/aragog/cfg/abe_liquid.cfg
+++ b/aragog/cfg/abe_liquid.cfg
@@ -22,8 +22,6 @@ inner_boundary_condition = 2
 inner_boundary_value = 0
 emissivity = 1
 equilibrium_temperature = 273
-# 0.55 of total radius
-core_radius = 3504050
 core_density = 10738.332568062382
 core_heat_capacity = 880
 

--- a/aragog/cfg/abe_mixed.cfg
+++ b/aragog/cfg/abe_mixed.cfg
@@ -22,8 +22,6 @@ inner_boundary_condition = 2
 inner_boundary_value = 0
 emissivity = 1
 equilibrium_temperature = 273
-# 0.55 of total radius
-core_radius = 3504050
 core_density = 10738.332568062382
 core_heat_capacity = 880
 

--- a/aragog/cfg/abe_mixed_lookup.cfg
+++ b/aragog/cfg/abe_mixed_lookup.cfg
@@ -22,8 +22,6 @@ inner_boundary_condition = 2
 inner_boundary_value = 0
 emissivity = 1
 equilibrium_temperature = 273
-# 0.55 of total radius
-core_radius = 3504050
 core_density = 10738.332568062382
 core_heat_capacity = 880
 

--- a/aragog/cfg/abe_solid.cfg
+++ b/aragog/cfg/abe_solid.cfg
@@ -22,8 +22,6 @@ inner_boundary_condition = 3
 inner_boundary_value = 4000
 emissivity = 1
 equilibrium_temperature = 273
-# 0.55 of total radius
-core_radius = 3504050
 core_density = 10738.332568062382
 core_heat_capacity = 880
 

--- a/aragog/parser.py
+++ b/aragog/parser.py
@@ -142,7 +142,6 @@ class _BoundaryConditionsParameters:
     inner_boundary_value: float
     emissivity: float
     equilibrium_temperature: float
-    core_radius: float
     core_density: float
     core_heat_capacity: float
     scalings_: _ScalingsParameters = field(init=False)
@@ -155,7 +154,6 @@ class _BoundaryConditionsParameters:
         """
         self.scalings_ = scalings
         self.equilibrium_temperature /= self.scalings_.temperature
-        self.core_radius /= self.scalings_.radius
         self.core_density /= self.scalings_.density
         self.core_heat_capacity /= self.scalings_.heat_capacity
         self._scale_inner_boundary_condition()


### PR DESCRIPTION
Implemented the core cooling boundary conditions following Bower et al., 2018.

Removed the core_radius key in the config parser as it should be equal to the inner radius and creates confusion.