### PR TITLE
Add basic publishing workflow.

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,28 @@
+name: Publish on PyPI
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f pyproject.toml ]; then pip install .; fi
+
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This work adds basic publishing workflow.

Once this is merged, the workflow will be automatically triggered when doing a Github release and will published the tagged version on PyPI.