### PR TITLE
Calculate core mass 

### DIFF
--- a/aragog/__init__.py
+++ b/aragog/__init__.py
@@ -18,7 +18,7 @@
 
 from __future__ import annotations
 
-__version__: str = "0.1.3-alpha"
+__version__: str = "0.1.4-alpha"
 
 import importlib.resources
 import logging

--- a/aragog/mesh.py
+++ b/aragog/mesh.py
@@ -472,6 +472,7 @@ class AdamsWilliamsonEOS:
         Returns:
             Pressure
         """
+
         pressure: npt.NDArray = -self._adiabatic_bulk_modulus * np.log(
             (
                 self._adiabatic_bulk_modulus

--- a/aragog/mesh.py
+++ b/aragog/mesh.py
@@ -472,7 +472,6 @@ class AdamsWilliamsonEOS:
         Returns:
             Pressure
         """
-
         pressure: npt.NDArray = -self._adiabatic_bulk_modulus * np.log(
             (
                 self._adiabatic_bulk_modulus

--- a/aragog/output.py
+++ b/aragog/output.py
@@ -159,7 +159,10 @@ class Output:
 
     @property
     def mantle_mass(self) -> float:
-        """Mantle mass comptuted from the AdamsWilliamsonEOS"""
+        """Mantle mass computed from the AdamsWilliamsonEOS"""
+
+        enclosed = self.evaluator.mesh.basic.eos.get_mass_within_radii(self.evaluator.mesh.basic.outer_boundary)
+
         return (
             self.evaluator.mesh.basic.eos.get_mass_within_radii(
                 self.evaluator.mesh.basic.outer_boundary
@@ -167,6 +170,22 @@ class Output:
             * self.parameters.scalings.density
             * np.power(self.parameters.scalings.radius, 3)
         )
+
+    @property
+    def core_mass(self) -> float:
+        """Core mass computed with constant density"""
+
+        # core radius
+        R_core = self.evaluator.mesh.basic.inner_boundary * self.parameters.scalings.radius
+
+        # core volume
+        volume = 4 * np.pi * (R_core**3) / 3
+
+        # core density
+        rho = self.parameters.scalings.density * self.parameters.boundary_conditions.core_density
+
+        # core mass
+        return rho * volume
 
     @property
     def solidus_K_staggered(self) -> npt.NDArray:

--- a/aragog/output.py
+++ b/aragog/output.py
@@ -160,9 +160,6 @@ class Output:
     @property
     def mantle_mass(self) -> float:
         """Mantle mass computed from the AdamsWilliamsonEOS"""
-
-        enclosed = self.evaluator.mesh.basic.eos.get_mass_within_radii(self.evaluator.mesh.basic.outer_boundary)
-
         return (
             self.evaluator.mesh.basic.eos.get_mass_within_radii(
                 self.evaluator.mesh.basic.outer_boundary

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ copyright = "2024, Dan J. Bower"  # Created by Sphinx, so pylint: disable=W0622
 author = "Dan J. Bower"
 
 # The full version, including alpha/beta/rc tags
-release = "0.1.3-alpha"
+release = "0.1.4-alpha"
 
 
 # -- General configuration ---------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aragog"
-version = "0.1.3-alpha"
+version = "0.1.4-alpha"
 description = "1-D interior dynamics of rocky mantles that are solid, liquid, or mixed phase"
 authors = ["Dan J Bower <djbower@users.noreply.github.com>"]
 license = "GPL-3.0-or-later"
@@ -22,7 +22,7 @@ typing-extensions = "^4.10.0"
 sphinx = {version = "7.2.6", optional = true}
 sphinx-rtd-theme = {version = "2.0.0", optional = true}
 sphinxcontrib-bibtex = {version = "2.6.3", optional = true}
-setuptools = {version = "69.2.0", optional = true}
+setuptools = {version = "70.0.0", optional = true}
 click = "^8.1.3"
 platformdirs = "^3.10.0"
 osfclient = "^0.0.5"

--- a/tests/test_phase.py
+++ b/tests/test_phase.py
@@ -37,7 +37,7 @@ pressure: npt.NDArray = np.atleast_2d([0, 135e9]).T
 
 def test_version():
     """Test version."""
-    assert __version__ == "0.1.3-alpha"
+    assert __version__ == "0.1.4-alpha"
 
 
 def test_liquid_constant_properties(helper):


### PR DESCRIPTION
Adds a property to the aragog Output object for calculating the core mass. This is needed in PROTEUS for determining the total interior mass, and thereby the total mass of the planet.

Also updates the setuptools dependency version to resolve https://github.com/ExPlanetology/aragog/security/dependabot/2

Version "0.1.4-alpha".