### PR TITLE
Store radiogenic heat production

### DIFF
--- a/aragog/__init__.py
+++ b/aragog/__init__.py
@@ -18,7 +18,7 @@
 
 from __future__ import annotations
 
-__version__: str = "0.1.4-alpha"
+__version__: str = "0.1.5-alpha"
 
 import importlib.resources
 import logging

--- a/aragog/output.py
+++ b/aragog/output.py
@@ -161,11 +161,6 @@ class Output:
         return self.evaluator.mesh.basic.radii * self.parameters.scalings.radius * 1.0e-3
 
     @property
-    def radii_km_staggered(self) -> npt.NDArray:
-        """Radii of the staggered mesh in km"""
-        return self.evaluator.mesh.staggered.radii * self.parameters.scalings.radius * 1.0e-3
-
-    @property
     def pressure_GPa_basic(self) -> npt.NDArray:
         """Pressure of the basic mesh in GPa"""
         return self.evaluator.mesh.basic.eos.pressure * self.parameters.scalings.pressure * 1.0e-9

--- a/aragog/output.py
+++ b/aragog/output.py
@@ -94,6 +94,16 @@ class Output:
         )
 
     @property
+    def heating(self) -> npt.NDArray:
+        """Internal heat generation at staggered nodes"""
+        return self.state.heating * self.parameters.scalings.power_per_mass
+
+    @property
+    def heating_radio(self) -> npt.NDArray:
+        """Internal heat generation from radioactive decay at staggered nodes"""
+        return self.state.heating_radio * self.parameters.scalings.power_per_mass
+
+    @property
     def liquidus_K_staggered(self) -> npt.NDArray:
         """Liquidus"""
         return self.evaluator.phases.mixed.liquidus() * self.parameters.scalings.temperature

--- a/aragog/output.py
+++ b/aragog/output.py
@@ -192,18 +192,9 @@ class Output:
     def mass_staggered(self) -> npt.NDArray:
         """Mass of each layer on staggered mesh"""
         return (
-            self.evaluator.mesh.staggered.eos.get_mass_element(
-                self.evaluator.mesh.staggered.radii
-            )
-            * self.parameters.scalings.density
-            * np.power(self.parameters.scalings.radius, 3)
-        )
-
-    @property
-    def mass_basic(self) -> npt.NDArray:
-        """Mass of each layer on basic mesh"""
-        return (
-            self.evaluator.mesh.basic.eos.get_mass_element(
+            # shells centred on staggered nodes
+            self.evaluator.mesh.staggered.eos.get_mass_within_shell(
+                # shell upper and lower radii set by basic nodes
                 self.evaluator.mesh.basic.radii
             )
             * self.parameters.scalings.density
@@ -334,12 +325,13 @@ class Output:
         _add_mesh_variable("radius_b", self.radii_km_basic, "km")
         _add_mesh_variable("pres_b", self.pressure_GPa_basic, "GPa")
         _add_mesh_variable("temp_b", self.temperature_K_basic, "K")
-        _add_mesh_variable("mass_b", self.mass_basic, "kg")
         _add_mesh_variable("phi_b", self.melt_fraction_basic, "")
         _add_mesh_variable("Fconv_b", self.convective_heat_flux_basic, "W m-2")
         _add_mesh_variable("log10visc_b", self.log10_viscosity_basic, "Pa s")
         _add_mesh_variable("density_b", self.density_basic, "kg m-3")
         _add_mesh_variable("heatcap_b", self.heat_capacity_basic, "J kg-1 K-1")
+
+        _add_mesh_variable("mass_s", self.mass_staggered, "kg")
         _add_mesh_variable("Hradio_s", self.heating_radio, "W kg-1")
         _add_mesh_variable("Htotal_s", self.heating, "W kg-1")
 

--- a/aragog/output.py
+++ b/aragog/output.py
@@ -104,6 +104,11 @@ class Output:
         return self.state.heating_radio * self.parameters.scalings.power_per_mass
 
     @property
+    def heating_tidal(self) -> npt.NDArray:
+        """Internal heat generation from tidal heat dissipation at staggered nodes"""
+        raise NotImplementedError
+
+    @property
     def liquidus_K_staggered(self) -> npt.NDArray:
         """Liquidus"""
         return self.evaluator.phases.mixed.liquidus() * self.parameters.scalings.temperature
@@ -186,14 +191,24 @@ class Output:
     @property
     def mass_staggered(self) -> npt.NDArray:
         """Mass of each layer on staggered mesh"""
-        dm = self.evaluator.mesh.staggered.eos.get_mass_element(self.evaluator.mesh.staggered.radii)
-        return dm * self.parameters.scalings.density * self.parameters.scalings.volume
+        return (
+            self.evaluator.mesh.staggered.eos.get_mass_element(
+                self.evaluator.mesh.staggered.radii
+            )
+            * self.parameters.scalings.density
+            * np.power(self.parameters.scalings.radius, 3)
+        )
 
     @property
     def mass_basic(self) -> npt.NDArray:
         """Mass of each layer on basic mesh"""
-        dm = self.evaluator.mesh.basic.eos.get_mass_element(self.evaluator.mesh.basic.radii)
-        return dm * self.parameters.scalings.density * self.parameters.scalings.volume
+        return (
+            self.evaluator.mesh.basic.eos.get_mass_element(
+                self.evaluator.mesh.basic.radii
+            )
+            * self.parameters.scalings.density
+            * np.power(self.parameters.scalings.radius, 3)
+        )
 
     @property
     def core_mass(self) -> float:

--- a/aragog/parser.py
+++ b/aragog/parser.py
@@ -370,8 +370,9 @@ class _Radionuclide:
             time: Time
 
         Returns:
-            Radiogenic heating [W/kg] as a float if time is a float, otherwise a numpy row array where
-                each entry in the row is associated with a single time in the time array.
+            Radiogenic heat production (power per unit mass) as a float if time is a float,
+                otherwise a numpy row array where each entry in the row is associated
+                with a single time in the time array.
         """
         arg: npt.NDArray | float = np.log(2) * (self.t0_years - time) / self.half_life_years
         heating: npt.NDArray | float = (

--- a/aragog/parser.py
+++ b/aragog/parser.py
@@ -107,7 +107,6 @@ class _ScalingsParameters:
     thermal_conductivity: float = field(init=False)
     viscosity: float = field(init=False)
     time_years: float = field(init=False)
-    volume: float = field(init=False)
     stefan_boltzmann_constant: float = field(init=False)
 
     def __post_init__(self) -> None:
@@ -126,7 +125,6 @@ class _ScalingsParameters:
         self.thermal_conductivity = self.power_per_volume * self.area / self.temperature
         self.viscosity = self.pressure * self.time
         self.time_years = self.time / constants.Julian_year  # Equivalent to TIMEYRS C code
-        self.volume = np.power(self.radius, 3)
         # Stefan-Boltzmann units for dimensional are W/m^2/K^4
         self.stefan_boltzmann_constant: float = codata.value("Stefan-Boltzmann constant")
         self.stefan_boltzmann_constant /= (
@@ -372,7 +370,7 @@ class _Radionuclide:
             time: Time
 
         Returns:
-            Radiogenic heating as a float if time is a float, otherwise a numpy row array where
+            Radiogenic heating [W/kg] as a float if time is a float, otherwise a numpy row array where
                 each entry in the row is associated with a single time in the time array.
         """
         arg: npt.NDArray | float = np.log(2) * (self.t0_years - time) / self.half_life_years

--- a/aragog/parser.py
+++ b/aragog/parser.py
@@ -107,6 +107,7 @@ class _ScalingsParameters:
     thermal_conductivity: float = field(init=False)
     viscosity: float = field(init=False)
     time_years: float = field(init=False)
+    volume: float = field(init=False)
     stefan_boltzmann_constant: float = field(init=False)
 
     def __post_init__(self) -> None:
@@ -125,6 +126,7 @@ class _ScalingsParameters:
         self.thermal_conductivity = self.power_per_volume * self.area / self.temperature
         self.viscosity = self.pressure * self.time
         self.time_years = self.time / constants.Julian_year  # Equivalent to TIMEYRS C code
+        self.volume = np.power(self.radius, 3)
         # Stefan-Boltzmann units for dimensional are W/m^2/K^4
         self.stefan_boltzmann_constant: float = codata.value("Stefan-Boltzmann constant")
         self.stefan_boltzmann_constant /= (

--- a/aragog/solver.py
+++ b/aragog/solver.py
@@ -80,6 +80,7 @@ class State:
     _eddy_diffusivity: npt.NDArray = field(init=False)
     _heat_flux: npt.NDArray = field(init=False)
     _heating: npt.NDArray = field(init=False)
+    _heating_radio: npt.NDArray = field(init=False)
     _is_convective: npt.NDArray = field(init=False)
     _reynolds_number: npt.NDArray = field(init=False)
     _super_adiabatic_temperature_gradient: npt.NDArray = field(init=False)
@@ -176,6 +177,11 @@ class State:
     def heating(self) -> npt.NDArray:
         """The total heating rate according to the heat sources specified in the configuration."""
         return self._heating
+
+    @property
+    def heating_radio(self) -> npt.NDArray:
+        """The radiogenic heating rate."""
+        return self._heating_radio
 
     @property
     def heat_flux(self) -> npt.NDArray:
@@ -306,9 +312,11 @@ class State:
         if self._settings.mixing:
             self._heat_flux += self.mixing_flux
         # Heating
-        self._heating = np.zeros_like(self.temperature_staggered)
+        self._heating       = np.zeros_like(self.temperature_staggered)
+        self._heating_radio = np.zeros_like(self.temperature_staggered)
         if self._settings.radionuclides:
-            self._heating += self.radiogenic_heating(time)
+            self._heating_radio = self.radiogenic_heating(time)
+            self._heating += self._heating_radio
 
 
 @dataclass

--- a/aragog/solver.py
+++ b/aragog/solver.py
@@ -56,8 +56,8 @@ class State:
         evaluator: Evaluator
         critical_reynolds_number: Critical Reynolds number
         gravitational_separation_flux: Gravitational separation flux at the basic nodes
-        heating: Heat generation at the staggered nodes
-        heat_flux: Heat flux at the basic nodes
+        heating: Heat production at the staggered nodes (power per unit mass)
+        heat_flux: Heat flux at the basic nodes (power per unit area)
         inviscid_regime: True if the flow is inviscid and otherwise False, at the basic nodes
         inviscid_velocity: Inviscid velocity at the basic nodes
         is_convective: True if the flow is convecting and otherwise False, at the basic nodes
@@ -137,25 +137,24 @@ class State:
 
         return convective_heat_flux
 
-    def radiogenic_heating(self, time: FloatOrArray) -> FloatOrArray:
+    def radiogenic_heating(self, time: float) -> npt.NDArray:
         """Radiogenic heating
 
         Args:
             time: Time
 
         Returns:
-            Radiogenic heating as a single column (in a 2-D array) if time is a float, otherwise a
-                2-D array with each column associated with a single time in the time array.
+            Radiogenic heating (power per unit mass) at each layer of the staggered
+                mesh, at a given point in time.
         """
-        radiogenic_heating_float: FloatOrArray = 0
+
+        # Total heat production at a given time (power per unit mass)
+        radio_heating_float: float = 0
         for radionuclide in self._evaluator.radionuclides:
-            radiogenic_heating_float += radionuclide.get_heating(time)
+            radio_heating_float += radionuclide.get_heating(time)
 
-        radiogenic_heating: FloatOrArray = radiogenic_heating_float * (
-            self.phase_staggered.density() / self.capacitance_staggered()
-        )
-
-        return radiogenic_heating
+        # Convert to 1D array (assuming abundances are constant)
+        return radio_heating_float * np.ones_like(self.temperature_staggered)
 
     @property
     def critical_reynolds_number(self) -> float:
@@ -175,13 +174,18 @@ class State:
 
     @property
     def heating(self) -> npt.NDArray:
-        """The total heating rate according to the heat sources specified in the configuration."""
+        """The power generation according to the heat sources specified in the configuration."""
         return self._heating
 
     @property
     def heating_radio(self) -> npt.NDArray:
-        """The radiogenic heating rate."""
+        """The radiogenic power generation."""
         return self._heating_radio
+
+    @property
+    def heating_tidal(self) -> npt.NDArray:
+        """The tidal power generation."""
+        raise NotImplementedError
 
     @property
     def heat_flux(self) -> npt.NDArray:
@@ -301,7 +305,8 @@ class State:
             self.viscous_regime, self._viscous_velocity, self._inviscid_velocity
         )
         self._eddy_diffusivity *= self._evaluator.mesh.basic.mixing_length
-        # Heat flux
+
+        # Heat flux (power per unit area)
         self._heat_flux = np.zeros_like(self.temperature_basic)
         if self._settings.conduction:
             self._heat_flux += self.conductive_heat_flux()
@@ -311,13 +316,17 @@ class State:
             self._heat_flux += self.gravitational_separation_flux
         if self._settings.mixing:
             self._heat_flux += self.mixing_flux
-        # Heating
+
+        # Heating (power per unit mass)
         self._heating       = np.zeros_like(self.temperature_staggered)
         self._heating_radio = np.zeros_like(self.temperature_staggered)
+
         if self._settings.radionuclides:
             self._heating_radio = self.radiogenic_heating(time)
             self._heating += self._heating_radio
 
+        if self._settings.tidal:
+            raise NotImplementedError
 
 @dataclass
 class Evaluator:
@@ -447,10 +456,13 @@ class Solver:
             self.state.capacitance_staggered() * self.evaluator.mesh.basic.volume
         )
 
+        # Heating rate (dT/dt) from flux divergence (power per unit area)
         dTdt: npt.NDArray = -delta_energy_flux / capacitance
         logger.debug("dTdt (fluxes only) = %s", dTdt)
 
-        dTdt += self.state.heating
+        # Additional heating rate (dT/dt) from internal heating (power per unit mass)
+        dTdt += self.state.heating * (self.state.phase_staggered.density() / self.state.capacitance_staggered())
+
         logger.debug("dTdt (with internal heating) = %s", dTdt)
 
         return dTdt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ copyright = "2024, Dan J. Bower"  # Created by Sphinx, so pylint: disable=W0622
 author = "Dan J. Bower"
 
 # The full version, including alpha/beta/rc tags
-release = "0.1.4-alpha"
+release = "0.1.5-alpha"
 
 
 # -- General configuration ---------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aragog"
-version = "0.1.4-alpha"
+version = "0.1.5-alpha"
 description = "1-D interior dynamics of rocky mantles that are solid, liquid, or mixed phase"
 authors = ["Dan J Bower <djbower@users.noreply.github.com>"]
 license = "GPL-3.0-or-later"

--- a/tests/test_phase.py
+++ b/tests/test_phase.py
@@ -37,7 +37,7 @@ pressure: npt.NDArray = np.atleast_2d([0, 135e9]).T
 
 def test_version():
     """Test version."""
-    assert __version__ == "0.1.4-alpha"
+    assert __version__ == "0.1.5-alpha"
 
 
 def test_liquid_constant_properties(helper):


### PR DESCRIPTION
Stores the radiogenic heat production and makes it available through the Output class. Closes #32. This is also saved to the output NetCDF files.

This allows PROTEUS to quantify the total energy flux `F_radio` arising from the radiogenic heating, which is important for tracking the planet's energy budget when coupling to an atmosphere module.

The most significant internal change here is that the quantities `State._heating` and `State._heating_radio` in `solver.py` now store heat production rates (power per unit mass, W/kg when scaled). Previously they stored the component of the heating rate (dT/dt) associated with internal heat production. Storing these as dT/dt was not only inconsistent with the equivalent SPIDER quantities (`Hradio_s`, etc) but also made it difficult to extract the global heat flux from the solver.

I have compared the heat production rate (W/kg) with that in SPIDER, and Aragog seems to be producing the exact same values: 3.42359989e-11 W/kg for the default configuration at t=0. This works out to `F_radio` approx 0.8 W/m^2.