### PR TITLE
Initial tidal heating implementation

### DIFF
--- a/aragog/__init__.py
+++ b/aragog/__init__.py
@@ -18,7 +18,7 @@
 
 from __future__ import annotations
 
-__version__: str = "0.1.5-alpha"
+__version__: str = "0.1.6-alpha"
 
 import os
 import importlib.resources

--- a/aragog/output.py
+++ b/aragog/output.py
@@ -106,7 +106,7 @@ class Output:
     @property
     def heating_tidal(self) -> npt.NDArray:
         """Internal heat generation from tidal heat dissipation at staggered nodes"""
-        raise NotImplementedError
+        raise self.state.heating_tidal * self.parameters.scalings.power_per_mass
 
     @property
     def liquidus_K_staggered(self) -> npt.NDArray:
@@ -328,6 +328,7 @@ class Output:
 
         _add_mesh_variable("mass_s", self.mass_staggered, "kg")
         _add_mesh_variable("Hradio_s", self.heating_radio, "W kg-1")
+        _add_mesh_variable("Htidal_s", self.heating_tidal, "W kg-1")
         _add_mesh_variable("Htotal_s", self.heating, "W kg-1")
 
         # Close the dataset

--- a/aragog/output.py
+++ b/aragog/output.py
@@ -254,6 +254,15 @@ class Output:
         )
 
     @property
+    def log10_viscosity_staggered(self) -> npt.NDArray:
+        """Viscosity of the staggered mesh"""
+        return np.log10(
+            self.state.phase_staggered.viscosity()
+            * self.parameters.scalings.viscosity
+            * np.ones(self.shape_staggered)
+        )
+
+    @property
     def solution_top_temperature(self) -> float:
         """Solution (last iteration) temperature at the top of the domain (planet surface)"""
         return self.temperature_K_basic[-1, -1]
@@ -323,9 +332,9 @@ class Output:
         _add_mesh_variable("phi_b", self.melt_fraction_basic, "")
         _add_mesh_variable("Fconv_b", self.convective_heat_flux_basic, "W m-2")
         _add_mesh_variable("log10visc_b", self.log10_viscosity_basic, "Pa s")
+        _add_mesh_variable("log10visc_s", self.log10_viscosity_staggered, "Pa s")
         _add_mesh_variable("density_b", self.density_basic, "kg m-3")
         _add_mesh_variable("heatcap_b", self.heat_capacity_basic, "J kg-1 K-1")
-
         _add_mesh_variable("mass_s", self.mass_staggered, "kg")
         _add_mesh_variable("Hradio_s", self.heating_radio, "W kg-1")
         _add_mesh_variable("Htidal_s", self.heating_tidal, "W kg-1")

--- a/aragog/output.py
+++ b/aragog/output.py
@@ -106,7 +106,7 @@ class Output:
     @property
     def heating_tidal(self) -> npt.NDArray:
         """Internal heat generation from tidal heat dissipation at staggered nodes"""
-        raise self.state.heating_tidal * self.parameters.scalings.power_per_mass
+        return self.state.heating_tidal * self.parameters.scalings.power_per_mass
 
     @property
     def liquidus_K_staggered(self) -> npt.NDArray:

--- a/aragog/parser.py
+++ b/aragog/parser.py
@@ -214,6 +214,18 @@ class _EnergyParameters:
     radionuclides: bool
     tidal: bool
 
+    # TODO: allow this to be loaded from a file or passed as an array.
+    tidal_value: float = 0.0 # Power per unit mass
+
+    def scale_attributes(self, scalings: _ScalingsParameters) -> None:
+        """Scales the attributes.
+
+        Args:
+            scalings: scalings
+        """
+        self.scalings_ = scalings
+        self.tidal_value /= self.scalings.power_per_mass
+
 
 @dataclass
 class _InitialConditionParameters:

--- a/aragog/parser.py
+++ b/aragog/parser.py
@@ -224,7 +224,7 @@ class _EnergyParameters:
             scalings: scalings
         """
         self.scalings_ = scalings
-        self.tidal_value /= self.scalings.power_per_mass
+        self.tidal_value /= self.scalings_.power_per_mass
 
 
 @dataclass

--- a/aragog/solver.py
+++ b/aragog/solver.py
@@ -348,6 +348,7 @@ class State:
             self._heating += self._heating_radio
 
         if self._settings.tidal:
+            self._heating_tidal = self.tidal_heating()
             self._heating += self._heating_tidal
 
 @dataclass

--- a/aragog/solver.py
+++ b/aragog/solver.py
@@ -173,7 +173,7 @@ class State:
         # Total heat production at a given time (power per unit mass)
         tidal_heating_float: float = self._settings.tidal_value
 
-        # Convert to 1D array (assuming abundances are constant)
+        # Convert to 1D array (assuming that tidal heating is equal at each level)
         return tidal_heating_float * np.ones_like(self.temperature_staggered)
 
 

--- a/aragog/solver.py
+++ b/aragog/solver.py
@@ -206,7 +206,7 @@ class State:
     @property
     def heating_tidal(self) -> npt.NDArray:
         """The tidal power generation."""
-        raise self._heating_tidal
+        return self._heating_tidal
 
     @property
     def heat_flux(self) -> npt.NDArray:

--- a/aragog/solver.py
+++ b/aragog/solver.py
@@ -56,7 +56,9 @@ class State:
         evaluator: Evaluator
         critical_reynolds_number: Critical Reynolds number
         gravitational_separation_flux: Gravitational separation flux at the basic nodes
-        heating: Heat production at the staggered nodes (power per unit mass)
+        heating: Total internal heat production at the staggered nodes (power per unit mass)
+        heating_radio: Radiogenic heat production at the staggered nodes (power per unit mass)
+        heating_tidal: Tidal heat production at the staggered nodes (power per unit mass)
         heat_flux: Heat flux at the basic nodes (power per unit area)
         inviscid_regime: True if the flow is inviscid and otherwise False, at the basic nodes
         inviscid_velocity: Inviscid velocity at the basic nodes
@@ -81,6 +83,7 @@ class State:
     _heat_flux: npt.NDArray = field(init=False)
     _heating: npt.NDArray = field(init=False)
     _heating_radio: npt.NDArray = field(init=False)
+    _heating_tidal: npt.NDArray = field(init=False)
     _is_convective: npt.NDArray = field(init=False)
     _reynolds_number: npt.NDArray = field(init=False)
     _super_adiabatic_temperature_gradient: npt.NDArray = field(init=False)
@@ -138,7 +141,7 @@ class State:
         return convective_heat_flux
 
     def radiogenic_heating(self, time: float) -> npt.NDArray:
-        """Radiogenic heating
+        """Radiogenic heating (constant with radius)
 
         Args:
             time: Time
@@ -155,6 +158,24 @@ class State:
 
         # Convert to 1D array (assuming abundances are constant)
         return radio_heating_float * np.ones_like(self.temperature_staggered)
+
+    def tidal_heating(self) -> npt.NDArray:
+        """Tidal heating (constant with radius)
+
+        Args:
+            time: Time
+
+        Returns:
+            Tidal heating (power per unit mass) at each layer of the staggered
+                mesh, at a given point in time.
+        """
+
+        # Total heat production at a given time (power per unit mass)
+        tidal_heating_float: float = self._settings.tidal_value
+
+        # Convert to 1D array (assuming abundances are constant)
+        return tidal_heating_float * np.ones_like(self.temperature_staggered)
+
 
     @property
     def critical_reynolds_number(self) -> float:
@@ -185,7 +206,7 @@ class State:
     @property
     def heating_tidal(self) -> npt.NDArray:
         """The tidal power generation."""
-        raise NotImplementedError
+        raise self._heating_tidal
 
     @property
     def heat_flux(self) -> npt.NDArray:
@@ -320,13 +341,14 @@ class State:
         # Heating (power per unit mass)
         self._heating       = np.zeros_like(self.temperature_staggered)
         self._heating_radio = np.zeros_like(self.temperature_staggered)
+        self._heating_tidal = np.zeros_like(self.temperature_staggered)
 
         if self._settings.radionuclides:
             self._heating_radio = self.radiogenic_heating(time)
             self._heating += self._heating_radio
 
         if self._settings.tidal:
-            raise NotImplementedError
+            self._heating += self._heating_tidal
 
 @dataclass
 class Evaluator:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ copyright = "2024, Dan J. Bower"  # Created by Sphinx, so pylint: disable=W0622
 author = "Dan J. Bower"
 
 # The full version, including alpha/beta/rc tags
-release = "0.1.5-alpha"
+release = "0.1.6-alpha"
 
 
 # -- General configuration ---------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aragog"
-version = "0.1.5-alpha"
+version = "0.1.6-alpha"
 description = "1-D interior dynamics of rocky mantles that are solid, liquid, or mixed phase"
 authors = ["Dan J Bower <djbower@users.noreply.github.com>"]
 license = "GPL-3.0-or-later"

--- a/tests/test_phase.py
+++ b/tests/test_phase.py
@@ -37,7 +37,7 @@ pressure: npt.NDArray = np.atleast_2d([0, 135e9]).T
 
 def test_version():
     """Test version."""
-    assert __version__ == "0.1.5-alpha"
+    assert __version__ == "0.1.6-alpha"
 
 
 def test_liquid_constant_properties(helper):


### PR DESCRIPTION
Allows tidal heating to be set using the Energy parameters class. This is currently just a floating point quantity (`tidal_value`) which is applied equally at each level of the mesh, alongside radiogenic heating. Closes #30.

Future work should consider allowing for inhomogeneously distributed tidal heat production.

Version 0.1.6