### PR TITLE
Corrected mass integration function.

### DIFF
--- a/aragog/mesh.py
+++ b/aragog/mesh.py
@@ -409,6 +409,7 @@ class AdamsWilliamsonEOS:
         b: float = self._adiabatic_bulk_modulus
         c: float = self._gravitational_acceleration
         d: float = self._outer_boundary
+        beta: float = b/(a*c) - d
 
         def mass_integral(radii_: FloatOrArray) -> npt.NDArray:
             """Mass within radii including arbitrary constant of integration.
@@ -421,16 +422,10 @@ class AdamsWilliamsonEOS:
             """
 
             mass: npt.NDArray = (
-                4
-                * np.pi
-                * (
-                    b
-                    * (
-                        a * c * radii_ * (a * c * (2 * d + radii_) - 2 * b)
-                        + 2 * np.square(b - a * c * d) * np.log(a * c * (radii_ - d) + b)
-                    )
-                    / (2 * np.square(a) + np.power(c, 3))
-                )
+                4 * np.pi * b/c* (
+                        -1.5 * beta * beta - beta * radii_ + 0.5 * radii_ * radii_
+                        + beta * beta * np.log(abs(beta + radii_))
+                        )
             )
             # + constant
 


### PR DESCRIPTION
I have found that the mass integration method in the EOS did not give the correct output. I re-derived the integration formula and get consistent results between code and on-paper.

With the following parameters:
- interior radius 6.371e6 m
- outer radius 3.504e6 m
- adiabatic bulk modulus 2,6e11 Pa
- surface density 4090 kg/m3
- graviational accelearion 9.81 m/s2

I obtain a mantle mass of 4.61e24 kg

I wanted to double check default parameters (surface density and adiabatic bulk modulus) with SPIDER but I realised they do not rely on the same equation. Is that OK @djbower ?

Pressure field in Aragog
$p(r)=-K_S\log\[ 1+\frac{\rho_S g (r-r_S)}{K_S}\]$

Pressure field in Spider
$p(r) = -\frac{\rho_S g}{\beta}(\exp(\beta(r_S-r))-1)$