### PR TITLE
Ls/initial temperature with adiabat

### DIFF
--- a/aragog/core.py
+++ b/aragog/core.py
@@ -18,14 +18,16 @@
 
 from __future__ import annotations
 
+import copy
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 import numpy as np
 import numpy.typing as npt
 
 from aragog.mesh import Mesh
+from aragog.phase import PhaseEvaluatorCollection
 from aragog.parser import (
     Parameters,
     _BoundaryConditionsParameters,
@@ -186,10 +188,13 @@ class InitialCondition:
     Args:
         parameters: Parameters
         mesh: Mesh
+        phases: PhaseEvaluatorProtocol
     """
 
     _parameters: Parameters
     _mesh: Mesh
+    _phases: PhaseEvaluatorCollection
+    phase_basic: PhaseEvaluatorProtocol = field(init=False)
 
     def __post_init__(self):
         self._settings: _InitialConditionParameters = self._parameters.initial_condition
@@ -203,6 +208,12 @@ class InitialCondition:
                     the number of staggered points {self._mesh.staggered.number_of_nodes}"
                 )
                 raise ValueError(msg)
+        elif self._settings.adiabat:
+            self.phase_staggered = copy.deepcopy(self._phases.active)
+            self.phase_staggered.set_pressure(self._mesh.staggered.pressure)
+            msg: str = (
+                 f"adiabatic case selected but not implemented yet")
+            raise ValueError(msg)
         else:
             self._temperature: npt.NDArray = self.get_linear()
 

--- a/aragog/core.py
+++ b/aragog/core.py
@@ -18,9 +18,8 @@
 
 from __future__ import annotations
 
-import copy
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -189,7 +188,7 @@ class InitialCondition:
     Args:
         parameters: Parameters
         mesh: Mesh
-        phases: PhaseEvaluatorProtocol
+        phases: PhaseEvaluatorCollection
     """
 
     _parameters: Parameters

--- a/aragog/core.py
+++ b/aragog/core.py
@@ -26,7 +26,6 @@ from typing import TYPE_CHECKING
 import numpy as np
 import numpy.typing as npt
 from scipy.integrate import solve_ivp
-import matplotlib.pyplot as plt
 
 from aragog.mesh import Mesh
 from aragog.phase import PhaseEvaluatorCollection
@@ -212,21 +211,6 @@ class InitialCondition:
                 raise ValueError(msg)
         elif self._settings.adiabat:
             self._temperature: npt.NDArray = self.get_adiabat(self._mesh.staggered.pressure[:,-1])
-            # Plot Temperature vs Pressure
-            fig, ax = plt.subplots(figsize=(10, 8))
-            ax.plot(self._temperature*4000, self._mesh.staggered.pressure[:,-1]*16303/1e9, 'b-', label="Adiabat")
-            ax.set_xlabel("Temperature (K)")
-            ax.set_ylabel("Pressure (GPa)")
-            ax.set_title("Adiabatic Temperature")
-            ax.legend()
-            ax.invert_yaxis()
-            ax.grid(True)
-            plt.show()
-
-            msg: str = (
-                 f"adiabatic case selected but not implemented yet")
-            raise ValueError(msg)
-            
         else:
             self._temperature: npt.NDArray = self.get_linear()
 

--- a/aragog/parser.py
+++ b/aragog/parser.py
@@ -233,6 +233,7 @@ class _InitialConditionParameters:
     surface_temperature: float = 4000
     basal_temperature: float = 4000
     init_file: str = ""
+    adiabat: bool = False
     from_field: bool = False
     scalings_: _ScalingsParameters = field(init=False)
 

--- a/aragog/phase.py
+++ b/aragog/phase.py
@@ -460,10 +460,10 @@ class CompositePhaseEvaluator(PhaseEvaluatorABC):
         self._mixed.update()
         self._set_blending_and_masks()
         self._density = self._get_composite("density")
-        self._dTdPs = self._get_composite("dTdPs")
         self._heat_capacity = self._get_composite("heat_capacity")
         self._thermal_conductivity = self._get_composite("thermal_conductivity")
         self._thermal_expansivity = self._get_composite("thermal_expansivity")
+        self._dTdPs = self._get_composite("dTdPs")
 
         name: str = "viscosity"
         log10_mixed_phase: npt.NDArray = np.log10(getattr(self._mixed, name)())

--- a/aragog/solver.py
+++ b/aragog/solver.py
@@ -386,8 +386,8 @@ class Evaluator:
     def __post_init__(self):
         self.mesh = Mesh(self._parameters)
         self.boundary_conditions = BoundaryConditions(self._parameters, self.mesh)
-        self.initial_condition = InitialCondition(self._parameters, self.mesh)
         self.phases = PhaseEvaluatorCollection(self._parameters)
+        self.initial_condition = InitialCondition(self._parameters, self.mesh, self.phases)
 
     @property
     def radionuclides(self) -> list[_Radionuclide]:


### PR DESCRIPTION
This work implements the initialisation of the temperature field from an adiabatic profile.

It performs the integration of the adiabatic temperature gradient dTdPs using the pressure field and the surface temperature.

The user needs to set the adiabat flag to True (as well as the surface temperature) in the initial condition parameter to trigger this initialisation method.