### PR TITLE
Support for optional output file compression

### DIFF
--- a/aragog/__init__.py
+++ b/aragog/__init__.py
@@ -18,7 +18,7 @@
 
 from __future__ import annotations
 
-__version__: str = "0.2.1-alpha"
+__version__: str = "0.2.2-alpha"
 
 import importlib.resources
 import logging

--- a/aragog/output.py
+++ b/aragog/output.py
@@ -268,12 +268,13 @@ class Output:
     def time_range(self) -> float:
         return self.times[-1] - self.times[0]
 
-    def write_at_time(self, file_path: str, tidx: int = -1) -> None:
+    def write_at_time(self, file_path: str, tidx: int = -1, compress: bool = False) -> None:
         """Write the state of the model at a particular time to a NetCDF4 file on the disk.
 
         Args:
             file_path: Path to the output file
             tidx: Index on the time axis at which to access the data
+            compress: Whether to compress the data
         """
 
         logger.debug("Writing i=%d NetCDF file to %s", tidx, file_path)
@@ -317,6 +318,9 @@ class Output:
                 key,
                 np.float64,
                 (mesh,),
+                compression="zlib" if compress else None,
+                shuffle = True,
+                complevel = 4
             )
             ds[key][:] = some_property[:, tidx]
             ds[key].units = units

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ copyright = "2024, Dan J. Bower"  # Created by Sphinx, so pylint: disable=W0622
 author = "Dan J. Bower"
 
 # The full version, including alpha/beta/rc tags
-release = "0.2.1-alpha"
+release = "0.2.2-alpha"
 
 
 # -- General configuration ---------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aragog"
-version = "0.2.1-alpha"
+version = "0.2.2-alpha"
 description = "1-D interior dynamics of rocky mantles that are solid, liquid, or mixed phase"
 authors = ["Dan J Bower <djbower@users.noreply.github.com>"]
 license = "GPL-3.0-or-later"

--- a/tests/test_phase.py
+++ b/tests/test_phase.py
@@ -37,7 +37,7 @@ pressure: npt.NDArray = np.atleast_2d([0, 135e9]).T
 
 def test_version():
     """Test version."""
-    assert __version__ == "0.2.1-alpha"
+    assert __version__ == "0.2.2-alpha"
 
 
 def test_liquid_constant_properties(helper):


### PR DESCRIPTION
With AGNI I found that enabling compression on the NetCDF output files can reduce their size by about 50%. This PR add the keyword argument `compress` to the function `write_at_time()`. When `compress=True`, the output data are compressed using zlib.  Closes #49

Interestingly, enabling compression with Aragog actually *increases* file size by about 50%. This is because the datasets are split into chunks before being compressed, which sometimes internally results in the NetCDF library padding the chunks with extra values in order to make them the right size. Since the Aragog output files are small, the extra padding outweighs the benefits of the compression. AGNI's output files are much larger in comparison.

I have therefore set `compress=False` as the default behaviour. This PR means that we can easily enable compression in the future, when the Aragog output files are more comprehensive.