### PR TITLE
Update NumPy version to be compatible with Python 3.13

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
-          python-version:  ['3.10','3.11','3.12', '3.13']
+          python-version:  ['3.10','3.11','3.12','3.13']
 
       - name: Install Poetry
         uses: snok/install-poetry@v1

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.12"
+          python-version:  ['3.10','3.11','3.12', '3.13']
 
       - name: Install Poetry
         uses: snok/install-poetry@v1

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
-          python-version:  ['3.12']
+          python-version: "3.12"
 
       - name: Install Poetry
         uses: snok/install-poetry@v1

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
-          python-version:  ['3.10','3.11','3.12','3.13']
+          python-version:  ['3.12']
 
       - name: Install Poetry
         uses: snok/install-poetry@v1

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12","3.13"]
 
     steps:
     - uses: actions/checkout@v3

--- a/aragog/__init__.py
+++ b/aragog/__init__.py
@@ -18,7 +18,7 @@
 
 from __future__ import annotations
 
-__version__: str = "0.2.3-alpha"
+__version__: str = "0.2.4-alpha"
 
 import importlib.resources
 import logging

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ copyright = "2024, Dan J. Bower"  # Created by Sphinx, so pylint: disable=W0622
 author = "Dan J. Bower"
 
 # The full version, including alpha/beta/rc tags
-release = "0.2.3-alpha"
+release = "0.2.4-alpha"
 
 
 # -- General configuration ---------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aragog"
-version = "0.2.3-alpha"
+version = "0.2.4-alpha"
 description = "1-D interior dynamics of rocky mantles that are solid, liquid, or mixed phase"
 authors = ["Dan J Bower <djbower@users.noreply.github.com>"]
 license = "GPL-3.0-or-later"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.10"
-numpy = "^2.0.0"
+numpy = ">=2.0.0"
 scipy = "^1.12.0"
 netCDF4 = "^1.7.0"
 thermochem = "^0.8.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.10"
-numpy = "^1.26.4"
+numpy = "^2.0.0"
 scipy = "^1.12.0"
 netCDF4 = "^1.7.0"
 thermochem = "^0.8.2"

--- a/tests/test_phase.py
+++ b/tests/test_phase.py
@@ -37,7 +37,7 @@ pressure: npt.NDArray = np.atleast_2d([0, 135e9]).T
 
 def test_version():
     """Test version."""
-    assert __version__ == "0.2.3-alpha"
+    assert __version__ == "0.2.4-alpha"
 
 
 def test_liquid_constant_properties(helper):


### PR DESCRIPTION
This PR updates Aragog to version 0.2.4-alpha which supports NumPy >= 2.0.0. This change aims to resolve CI failures on macOS with Python 3.13 by ensuring a pre-compiled NumPy 2.x wheel is used, avoiding potential numerical inconsistencies from source builds of older NumPy versions.

You can check the CI failure: [here](https://github.com/FormingWorlds/PROTEUS/actions/runs/15022135721/job/42213663171?pr=408)