### PR TITLE
Fixed divison by zero when calculating porosity

### DIFF
--- a/aragog/__init__.py
+++ b/aragog/__init__.py
@@ -18,7 +18,7 @@
 
 from __future__ import annotations
 
-__version__: str = "0.2.4-alpha"
+__version__: str = "0.2.5-alpha"
 
 import importlib.resources
 import logging

--- a/aragog/phase.py
+++ b/aragog/phase.py
@@ -313,7 +313,8 @@ class MixedPhaseEvaluator(PhaseEvaluatorABC):
         self._density = 1 / self._density
 
         # Porosity
-        self._porosity = (self._solid.density() - self.density()) / self.delta_density()
+        epsilon = 1e-10  # Used to avoid division by zero when dividing by the delta density for higher mass planets
+        self._porosity = (self._solid.density() - self.density()) / (self.delta_density() + epsilon)
 
         # Thermal conductivity
         self._thermal_conductivity = combine_properties(

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ copyright = "2024, Dan J. Bower"  # Created by Sphinx, so pylint: disable=W0622
 author = "Dan J. Bower"
 
 # The full version, including alpha/beta/rc tags
-release = "0.2.4-alpha"
+release = "0.2.5-alpha"
 
 
 # -- General configuration ---------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aragog"
-version = "0.2.4-alpha"
+version = "0.2.5-alpha"
 description = "1-D interior dynamics of rocky mantles that are solid, liquid, or mixed phase"
 authors = ["Dan J Bower <djbower@users.noreply.github.com>"]
 license = "GPL-3.0-or-later"

--- a/tests/test_phase.py
+++ b/tests/test_phase.py
@@ -37,7 +37,7 @@ pressure: npt.NDArray = np.atleast_2d([0, 135e9]).T
 
 def test_version():
     """Test version."""
-    assert __version__ == "0.2.4-alpha"
+    assert __version__ == "0.2.5-alpha"
 
 
 def test_liquid_constant_properties(helper):


### PR DESCRIPTION
This PR adds a small epsilon (1e-10) to the denominator in the porosity calculation: `self._porosity = (self._solid.density() - self.density()) / (self.delta_density() + epsilon)`
Motivation: 
While running a simulations with Aragog in PROTEUS, spanning masses from 1 to 20 Earth masses, I encountered persistent `RuntimeWarning: invalid value encountered in divide` errors for planets with masses ≥ 5 Earth masses. Despite PROTEUS continuing to run, the porosity array contained 0s and NaNs. 