### PR TITLE
Ls/update solver

### DIFF
--- a/aragog/__init__.py
+++ b/aragog/__init__.py
@@ -18,7 +18,7 @@
 
 from __future__ import annotations
 
-__version__: str = "0.2.5-alpha"
+__version__: str = "0.2.6-alpha"
 
 import importlib.resources
 import logging

--- a/aragog/solver.py
+++ b/aragog/solver.py
@@ -439,6 +439,19 @@ class Solver:
         self.evaluator = Evaluator(self.parameters)
         self.state = State(self.parameters, self.evaluator)
 
+    def reset(self) -> None:
+        """This function initializes the model, while keeping the previous state of the
+        PhaseEvaluatorCollection object. This avoids multiple loads of lookup table data
+        when running Aragog multiple times.
+        """
+        logger.info("Resetting %s", self.__class__.__name__)
+        # Update the Evaluator object except the phase properties
+        self.evaluator.mesh = Mesh(self.parameters)
+        self.evaluator.boundary_conditions = BoundaryConditions(self.parameters, self.evaluator.mesh)
+        self.evaluator.initial_condition = InitialCondition(self.parameters, self.evaluator.mesh, self.evaluator.phases)
+        # Reinstantiate the solver state
+        self.state = State(self.parameters, self.evaluator)
+
     @property
     def temperature_basic(self) -> npt.NDArray:
         """Temperature of the basic mesh in K"""

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ copyright = "2024, Dan J. Bower"  # Created by Sphinx, so pylint: disable=W0622
 author = "Dan J. Bower"
 
 # The full version, including alpha/beta/rc tags
-release = "0.2.5-alpha"
+release = "0.2.6-alpha"
 
 
 # -- General configuration ---------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aragog"
-version = "0.2.5-alpha"
+version = "0.2.6-alpha"
 description = "1-D interior dynamics of rocky mantles that are solid, liquid, or mixed phase"
 authors = ["Dan J Bower <djbower@users.noreply.github.com>"]
 license = "GPL-3.0-or-later"

--- a/tests/test_phase.py
+++ b/tests/test_phase.py
@@ -37,7 +37,7 @@ pressure: npt.NDArray = np.atleast_2d([0, 135e9]).T
 
 def test_version():
     """Test version."""
-    assert __version__ == "0.2.5-alpha"
+    assert __version__ == "0.2.6-alpha"
 
 
 def test_liquid_constant_properties(helper):


### PR DESCRIPTION
This work introduces the ability to reset the solver while keeping in memory the previous state of the phase object. This avoids loading multiple times the lookup data and makes the execution of Proteus much faster.