### PR TITLE
Ls/mass coordinates

### DIFF
--- a/aragog/cfg/abe_liquid.cfg
+++ b/aragog/cfg/abe_liquid.cfg
@@ -24,7 +24,6 @@ inner_boundary_condition = 2
 inner_boundary_value = 0
 emissivity = 1
 equilibrium_temperature = 273
-core_density = 10738.332568062382
 core_heat_capacity = 880
 
 [mesh]
@@ -33,6 +32,7 @@ outer_radius = 6371000
 inner_radius = 5371000
 number_of_nodes = 100
 mixing_length_profile = constant
+core_density = 10738.332568062382
 # static pressure profile derived from Adams-Williamson equation of state
 # surface density
 surface_density = 4090

--- a/aragog/cfg/abe_mixed.cfg
+++ b/aragog/cfg/abe_mixed.cfg
@@ -24,7 +24,6 @@ inner_boundary_condition = 2
 inner_boundary_value = 0
 emissivity = 1
 equilibrium_temperature = 273
-core_density = 10738.332568062382
 core_heat_capacity = 880
 
 [mesh]
@@ -33,6 +32,7 @@ outer_radius = 6371000
 inner_radius = 5371000
 number_of_nodes = 50
 mixing_length_profile = constant
+core_density = 10738.332568062382
 # static pressure profile derived from Adams-Williamson equation of state
 # surface density
 surface_density = 4090

--- a/aragog/cfg/abe_mixed_init.cfg
+++ b/aragog/cfg/abe_mixed_init.cfg
@@ -24,7 +24,6 @@ inner_boundary_condition = 2
 inner_boundary_value = 0
 emissivity = 1
 equilibrium_temperature = 273
-core_density = 10738.332568062382
 core_heat_capacity = 880
 
 [mesh]
@@ -34,6 +33,7 @@ inner_radius = 5371000
 number_of_nodes = 50
 mixing_length_profile = constant
 # user-defined EOS
+core_density = 10738.332568062382
 eos_method = 2
 eos_file = data/test/eos_test.dat
 

--- a/aragog/cfg/abe_mixed_lookup.cfg
+++ b/aragog/cfg/abe_mixed_lookup.cfg
@@ -24,7 +24,6 @@ inner_boundary_condition = 2
 inner_boundary_value = 0
 emissivity = 1
 equilibrium_temperature = 273
-core_density = 10738.332568062382
 core_heat_capacity = 880
 
 [mesh]
@@ -33,6 +32,7 @@ outer_radius = 6371000
 inner_radius = 5371000
 number_of_nodes = 100
 mixing_length_profile = constant
+core_density = 10738.332568062382
 # static pressure profile derived from Adams-Williamson equation of state
 # surface density
 surface_density = 4090

--- a/aragog/cfg/abe_solid.cfg
+++ b/aragog/cfg/abe_solid.cfg
@@ -24,7 +24,6 @@ inner_boundary_condition = 3
 inner_boundary_value = 4000
 emissivity = 1
 equilibrium_temperature = 273
-core_density = 10738.332568062382
 core_heat_capacity = 880
 
 [mesh]
@@ -33,6 +32,7 @@ outer_radius = 6371000
 inner_radius = 5371000
 number_of_nodes = 100
 mixing_length_profile = nearest_boundary
+core_density = 10738.332568062382
 # static pressure profile derived from Adams-Williamson equation of state
 # surface density
 surface_density = 4090

--- a/aragog/core.py
+++ b/aragog/core.py
@@ -69,7 +69,7 @@ class BoundaryConditions:
         if self._settings.inner_boundary_condition == 3:
             temperature_basic[0, :] = self._settings.inner_boundary_value
             dTdr[0, :] = (
-                2 * (temperature[0, :] - temperature_basic[0, :]) / self._mesh.basic.delta_radii[0]
+                2 * (temperature[0, :] - temperature_basic[0, :]) / self._mesh.basic.delta_mesh[0]
             )
         # Surface
         if self._settings.outer_boundary_condition == 5:
@@ -77,7 +77,7 @@ class BoundaryConditions:
             dTdr[-1, :] = (
                 2
                 * (temperature_basic[-1, :] - temperature[-1, :])
-                / self._mesh.basic.delta_radii[-1]
+                / self._mesh.basic.delta_mesh[-1]
             )
 
     def apply_temperature_boundary_conditions_melt(
@@ -95,14 +95,14 @@ class BoundaryConditions:
         if self._settings.inner_boundary_condition == 3:
             dphidr[0, :] = (
                 2 * (melt_fraction[0, :] - melt_fraction_basic[0, :])
-                / self._mesh.basic.delta_radii[0]
+                / self._mesh.basic.delta_mesh[0]
             )
         # Surface
         if self._settings.outer_boundary_condition == 5:
             dphidr[-1, :] = (
                 2
                 * (melt_fraction_basic[-1, :] - melt_fraction[-1, :])
-                / self._mesh.basic.delta_radii[-1]
+                / self._mesh.basic.delta_mesh[-1]
             )
 
     def apply_flux_boundary_conditions(self, state: State) -> None:

--- a/aragog/core.py
+++ b/aragog/core.py
@@ -69,15 +69,17 @@ class BoundaryConditions:
         if self._settings.inner_boundary_condition == 3:
             temperature_basic[0, :] = self._settings.inner_boundary_value
             dTdr[0, :] = (
-                2 * (temperature[0, :] - temperature_basic[0, :]) / self._mesh.basic.delta_mesh[0]
+                2 * (temperature[0, :] - temperature_basic[0, :])
+                / self._mesh.basic.delta_mesh[0]
+                * self._mesh.dxidr[0]
             )
         # Surface
         if self._settings.outer_boundary_condition == 5:
             temperature_basic[-1, :] = self._settings.outer_boundary_value
             dTdr[-1, :] = (
-                2
-                * (temperature_basic[-1, :] - temperature[-1, :])
+                2 * (temperature_basic[-1, :] - temperature[-1, :])
                 / self._mesh.basic.delta_mesh[-1]
+                * self._mesh.dxidr[-1]
             )
 
     def apply_temperature_boundary_conditions_melt(
@@ -101,8 +103,7 @@ class BoundaryConditions:
         # Surface
         if self._settings.outer_boundary_condition == 5:
             dphidr[-1, :] = (
-                2
-                * (melt_fraction_basic[-1, :] - melt_fraction[-1, :])
+                2 * (melt_fraction_basic[-1, :] - melt_fraction[-1, :])
                 / self._mesh.basic.delta_mesh[-1]
                 * self._mesh.dxidr[-1]
             )

--- a/aragog/core.py
+++ b/aragog/core.py
@@ -171,7 +171,7 @@ class BoundaryConditions:
             / 3
             * np.pi
             * np.power(self._mesh.basic.radii[0], 3)
-            * self._settings.core_density
+            * self._mesh.settings.core_density
             * self._settings.core_heat_capacity
         )
         cell_capacity = self._mesh.basic.volume[0] * state.capacitance_staggered()[0, :]

--- a/aragog/core.py
+++ b/aragog/core.py
@@ -96,6 +96,7 @@ class BoundaryConditions:
             dphidr[0, :] = (
                 2 * (melt_fraction[0, :] - melt_fraction_basic[0, :])
                 / self._mesh.basic.delta_mesh[0]
+                * self._mesh.dxidr[0]
             )
         # Surface
         if self._settings.outer_boundary_condition == 5:
@@ -103,6 +104,7 @@ class BoundaryConditions:
                 2
                 * (melt_fraction_basic[-1, :] - melt_fraction[-1, :])
                 / self._mesh.basic.delta_mesh[-1]
+                * self._mesh.dxidr[-1]
             )
 
     def apply_flux_boundary_conditions(self, state: State) -> None:

--- a/aragog/mesh.py
+++ b/aragog/mesh.py
@@ -202,7 +202,7 @@ class Mesh:
         if parameters.mesh.mass_coordinates:
             self._dxidr: npt.NDArray = self.get_dxidr_basic()
         else:
-            self._dxidr: npt.NDArray = np.ones(self.settings.number_of_nodes)
+            self._dxidr: npt.NDArray = np.ones_like(self.basic.radii)
         self._d_dr_transform: npt.NDArray = self._get_d_dr_transform_matrix()
         self._quantity_transform: npt.NDArray = self._get_quantity_transform_matrix()
 
@@ -212,8 +212,8 @@ class Mesh:
         return self._dxidr
 
     @cached_property
-    def effective_density(self) -> npt.NDArray:
-        return self.eos.effective_density
+    def staggered_effective_density(self) -> npt.NDArray:
+        return self.eos.staggered_effective_density
 
     @cached_property
     def basic_pressure(self) -> npt.NDArray:
@@ -236,7 +236,7 @@ class Mesh:
         basic_volumes = (np.power(basic_coordinates[1:,0],3.0)
             - np.power(basic_coordinates[:-1,0],3.0))
         mantle_mass = np.sum(
-            self.effective_density[:,0] * basic_volumes
+            self.staggered_effective_density[:,0] * basic_volumes
         )
         planet_density = (
             (core_mass + mantle_mass) / (np.power(basic_coordinates[-1,0],3.0)))
@@ -264,18 +264,58 @@ class Mesh:
             - np.power(basic_coordinates[:-1,:],3.0))
         for i in range(1, self.settings.number_of_nodes):
             basic_mass_coordinates[i:,:] += (
-                self.effective_density[i-1,:] * basic_volumes[i-1,:] / self._planet_density
+                self.staggered_effective_density[i-1,:] * basic_volumes[i-1,:] / self._planet_density
             )
 
         return np.power(basic_mass_coordinates, 1.0/3.0)
 
     def get_staggered_coordinates_from_mass_coordinates(self, staggered_mass_coordinates: npt.NDArray) -> npt.NDArray:
-        msg: str = "Mass coordinates not imlpemented yet."
-        raise NotImplementedError(msg)
+        """Computes the staggered spatial coordinates from staggered mass coordinates.
+
+        Args:
+            Staggered mass coordinates
+
+        Returns:
+            Staggered spatial coordinates
+        """
+
+        # Initialise the staggered spatial coordinate to the inner boundary
+        staggered_coordinates = (np.ones_like(staggered_mass_coordinates)
+            * np.power(self.settings.inner_radius,3.0))
+
+        # Add first half cell contribution
+        staggered_coordinates += (
+            self._planet_density
+             * (np.power(staggered_mass_coordinates[0,:],3.0)
+            - np.power(self.basic.mass_radii[0,:], 3.0))
+            / self.staggered_effective_density[0,:]
+        )
+
+        # Get spatial coordinates by adding individual cell contributions to the mantle mass
+        shell_effective_density = 0.5*(
+            self.staggered_effective_density[1:,:] + self.staggered_effective_density[:-1,:])
+        shell_mass_volumes = (np.power(staggered_mass_coordinates[1:,:],3.0)
+            - np.power(staggered_mass_coordinates[:-1,:],3.0))
+        for i in range(1,self.settings.number_of_nodes-1):
+            staggered_coordinates[i:,:] += (
+                self._planet_density
+                * shell_mass_volumes[i-1,:]
+                / shell_effective_density[i-1,:]
+            )
+
+        return np.power(staggered_coordinates, 1.0/3.0)
 
     def get_dxidr_basic(self) -> npt.NDArray:
-        msg: str = "Mass coordinates not imlpemented yet."
-        raise NotImplementedError(msg)
+        """Computes dxidr at basic nodes."""
+
+        dxidr = (
+            self.eos.basic_density
+            / self._planet_density
+            * np.power(self.basic.radii,2.0)
+            / np.power(self.basic.mass_radii,2.0)
+        )
+
+        return dxidr
 
     def get_constant_spacing(self) -> npt.NDArray:
         """Constant radius spacing across the mantle
@@ -321,7 +361,8 @@ class Mesh:
         transform[-1, -3] = - outer_delta_ratio / self.staggered.delta_mesh[-2].item()
 
         # Scale the transform matrix by dxi/dr at basic nodes
-        transform[:,:] *= self._dxidr[:, None]
+        for i in range(self.settings.number_of_nodes-1):
+            transform[:,i] *= self._dxidr[:, 0]
         logger.debug("_d_dr_transform_matrix = %s", transform)
 
         return transform
@@ -414,7 +455,10 @@ class EOS(ABC):
     """Generic EOS class"""
 
     @abstractmethod
-    def effective_density(self) -> npt.NDArray: ...
+    def staggered_effective_density(self) -> npt.NDArray: ...
+
+    @abstractmethod
+    def basic_density(self) -> npt.NDArray: ...
 
     @abstractmethod
     def basic_pressure(self) -> npt.NDArray: ...
@@ -451,7 +495,8 @@ class AdamsWilliamsonEOS(EOS):
         self._gravitational_acceleration: float = self._settings.gravitational_acceleration
         self._adiabatic_bulk_modulus: float = self._settings.adiabatic_bulk_modulus
         self._basic_pressure = self.get_pressure_from_radii(basic_radii)
-        self._effective_density = self.get_effective_density(basic_radii)
+        self._basic_density = self.get_density_from_radii(basic_radii)
+        self._staggered_effective_density = self.get_effective_density(basic_radii)
 
     @property
     def basic_pressure(self) -> npt.NDArray:
@@ -464,9 +509,14 @@ class AdamsWilliamsonEOS(EOS):
         return self._staggered_pressure
 
     @property
-    def effective_density(self) -> npt.NDArray:
-        """Effective density"""
-        return self._effective_density
+    def basic_density(self) -> npt.NDArray:
+        """Density at basic nodes"""
+        return self._basic_density
+
+    @property
+    def staggered_effective_density(self) -> npt.NDArray:
+        """Effective density at staggered nodes"""
+        return self._staggered_effective_density
 
     def set_staggered_pressure(self, staggered_radii: npt.NDArray,) -> None:
         """Set staggered pressure based on staggered radii."""
@@ -474,14 +524,14 @@ class AdamsWilliamsonEOS(EOS):
 
     def get_effective_density(self, radii) -> npt.NDArray:
         r"""
-        Computes effective density on staggered nodes using
-        density rho(r) integration over a spherical shell.
+        Computes effective density using density rho(r) integration
+        over a spherical shell bounded by radii
 
         Args:
-            radii: Radii array on basic nodes
+            radii: Radii array
 
         Returns:
-            Effective Density array on staggered nodes
+            Effective Density array
         """
 
         mass_shell = self.get_mass_within_shell(radii)
@@ -723,7 +773,10 @@ class UserDefinedEOS(EOS):
         self._interp_density = PchipInterpolator(settings.eos_radius, settings.eos_density)
         self._basic_pressure = self._interp_pressure(basic_radii).reshape(-1,1)
         basic_effective_density = self._interp_density(basic_radii).reshape(-1,1)
-        self._effective_density = 0.5*(basic_effective_density[:-1, :] + basic_effective_density[1:, :])
+        self._staggered_effective_density = 0.5*(
+            basic_effective_density[:-1, :] + basic_effective_density[1:, :])
+        # Assumes density and effective density are the same at basic nodes
+        self._basic_density = basic_effective_density
 
     @property
     def basic_pressure(self) -> npt.NDArray:
@@ -736,9 +789,14 @@ class UserDefinedEOS(EOS):
         return self._staggered_pressure
 
     @property
-    def effective_density(self) -> npt.NDArray:
-        """Effective density"""
-        return self._effective_density
+    def basic_density(self) -> npt.NDArray:
+        """Effective density at basic nodes"""
+        return self._basic_density
+
+    @property
+    def staggered_effective_density(self) -> npt.NDArray:
+        """Effective density at staggered nodes"""
+        return self._staggered_effective_density
 
     def set_staggered_pressure(self, staggered_radii: npt.NDArray,) -> None:
         """Set staggered pressure based on staggered radii."""

--- a/aragog/mesh.py
+++ b/aragog/mesh.py
@@ -148,6 +148,10 @@ class Mesh:
     eos: EOS = field(init=False)
 
     def __init__(self, parameters: Parameters):
+        if parameters.mesh.mass_coordinates:
+            msg: str = "Mass coordinates not imlpemented yet."
+            raise NotImplementedError(msg)
+
         self.settings: _MeshParameters = parameters.mesh
         basic_coordinates: npt.NDArray = self.get_constant_spacing()
         self.basic: FixedMesh = FixedMesh(

--- a/aragog/mesh.py
+++ b/aragog/mesh.py
@@ -40,12 +40,14 @@ class FixedMesh:
     Args:
         settings: Mesh parameters
         radii: Radii of the mesh
+        mass_radii: Mass coordinates of the mesh
         outer_boundary: Outer boundary for computing depth below the surface
         inner_boundary: Inner boundary for computing height above the base
 
     Attributes:
         settings: Mesh parameters
         radii: Radii of the mesh
+        mass_radii: Mass coordinates of the mesh
         outer_boundary: Outer boundary for computing depth below the surface
         inner_boundary: Inner boundary for computing height above the base
         area: Surface area
@@ -62,6 +64,7 @@ class FixedMesh:
 
     settings: _MeshParameters
     radii: npt.NDArray
+    mass_radii: npt.NDArray
     outer_boundary: float
     inner_boundary: float
 
@@ -78,7 +81,7 @@ class FixedMesh:
 
     @cached_property
     def delta_mesh(self) -> npt.NDArray:
-        return np.diff(self.radii, axis=0)
+        return np.diff(self.mass_radii, axis=0)
 
     @cached_property
     def depth(self) -> npt.NDArray:
@@ -155,11 +158,12 @@ class Mesh:
         self.settings: _MeshParameters = parameters.mesh
         basic_coordinates: npt.NDArray = self.get_constant_spacing()
         self.basic: FixedMesh = FixedMesh(
-            self.settings, basic_coordinates, np.max(basic_coordinates), np.min(basic_coordinates)
+            self.settings, basic_coordinates, basic_coordinates, np.max(basic_coordinates), np.min(basic_coordinates)
         )
         staggered_coordinates: npt.NDArray = self.basic.radii[:-1] + 0.5 * self.basic.delta_mesh
         self.staggered: FixedMesh = FixedMesh(
             self.settings,
+            staggered_coordinates,
             staggered_coordinates,
             self.basic.outer_boundary,
             self.basic.inner_boundary,

--- a/aragog/mesh.py
+++ b/aragog/mesh.py
@@ -214,8 +214,25 @@ class Mesh:
         )
         transform[1:-1, :-1] += np.diagflat(-1 / self.staggered.delta_radii)  # k=0 diagonal
         transform[1:-1:, 1:] += np.diagflat(1 / self.staggered.delta_radii)  # k=1 diagonal
-        transform[0, :] = transform[1, :]  # Backward difference at outer radius
-        transform[-1, :] = transform[-2, :]  # Forward difference at inner radius
+
+        # Gradient at boundaries can be extrapolated from the first two closests basic nodes
+        # This only affects the estimation of indivual components of heat fluxes when working
+        # with flux boundary conditions. Gradient at boundaries are overwritten when using
+        # temperature boundary conditions.
+
+        # Extrapolation of gradient at inner radius
+        inner_delta_ratio = self.basic.delta_radii[1].item() / self.basic.delta_radii[0].item()
+        transform[0, 0] = - (inner_delta_ratio + 1) / self.staggered.delta_radii[0].item()
+        transform[0, 1] = (inner_delta_ratio + 1) / self.staggered.delta_radii[0].item()
+        transform[0, 1] += inner_delta_ratio / self.staggered.delta_radii[1].item()
+        transform[0, 2] = - inner_delta_ratio / self.staggered.delta_radii[1].item()
+        # Extrapolation of gradient at outer radius
+        outer_delta_ratio: float = self.basic.delta_radii[-2].item() / self.basic.delta_radii[-1].item()
+        transform[-1, -1] = - (outer_delta_ratio + 1) / self.staggered.delta_radii[-1].item()
+        transform[-1, -2] = (outer_delta_ratio + 1) / self.staggered.delta_radii[-1].item()
+        transform[-1, -2] += outer_delta_ratio / self.staggered.delta_radii[-2].item()
+        transform[-1, -3] = - outer_delta_ratio / self.staggered.delta_radii[-2].item()
+
         logger.debug("_d_dr_transform_matrix = %s", transform)
 
         return transform
@@ -234,13 +251,14 @@ class Mesh:
 
         return d_dr_at_basic_nodes
 
-    # TODO: Compatibility with conforming boundary/initial conditions?
     def _get_quantity_transform_matrix(self) -> npt.NDArray:
         """A transform matrix for mapping quantities on the staggered mesh to the basic mesh.
 
         Uses backward and forward differences at the inner and outer radius, respectively, to
-        obtain the quantity values of the basic nodes at the innermost and outermost nodes. It may
-        be subsequently necessary to conform these outer boundaries to applied boundary conditions.
+        obtain the quantity values of the basic nodes at the innermost and outermost nodes.
+        When using temperature boundary conditions, values at outer boundaries will be overwritten.
+        When using flux boundary conditions, values at outer boundaries will be used to provide
+        estimate of individual components of heat fluxes though the total heat flux is imposed.
 
         Returns:
             The transform matrix
@@ -262,13 +280,14 @@ class Mesh:
 
         return transform
 
-    # TODO: Compatibility with conforming boundary/initial conditions?
     def quantity_at_basic_nodes(self, staggered_quantity: npt.NDArray) -> npt.NDArray:
         """Determines a quantity at the basic nodes that is defined at the staggered nodes.
 
         Uses backward and forward differences at the inner and outer radius, respectively, to
-        obtain the quantity values of the basic nodes at the innermost and outermost nodes. It may
-        be subsequently necessary to conform these outer boundaries to applied boundary conditions.
+        obtain the quantity values of the basic nodes at the innermost and outermost nodes.
+        When using temperature boundary conditions, values at outer boundaries will be overwritten.
+        When using flux boundary conditions, values at outer boundaries will be used to provide
+        estimate of individual components of heat fluxes though the total heat flux is imposed.
 
         Args:
             staggered_quantity: A quantity defined at the staggered nodes

--- a/aragog/mesh.py
+++ b/aragog/mesh.py
@@ -168,6 +168,7 @@ class Mesh:
             self.basic.outer_boundary,
             self.basic.inner_boundary,
         )
+        self._dxidr: npt.NDArray = np.ones(self.settings.number_of_nodes)
         self._d_dr_transform: npt.NDArray = self._get_d_dr_transform_matrix()
         self._quantity_transform: npt.NDArray = self._get_quantity_transform_matrix()
         if self.settings.eos_method == 1:
@@ -181,6 +182,11 @@ class Mesh:
         else:
             msg: str = (f"Unknown method to initialize Equation of State")
             raise ValueError(msg)
+
+    @property
+    def dxidr(self) -> npt.NDArray:
+        """dxi/dr at basic nodes"""
+        return self._dxidr
 
     @cached_property
     def effective_density(self) -> npt.NDArray:
@@ -237,6 +243,8 @@ class Mesh:
         transform[-1, -2] += outer_delta_ratio / self.staggered.delta_mesh[-2].item()
         transform[-1, -3] = - outer_delta_ratio / self.staggered.delta_mesh[-2].item()
 
+        # Scale the transform matrix by dxi/dr at basic nodes
+        transform[:,:] *= self._dxidr[:, None]
         logger.debug("_d_dr_transform_matrix = %s", transform)
 
         return transform

--- a/aragog/mesh.py
+++ b/aragog/mesh.py
@@ -186,7 +186,7 @@ class Mesh:
             self.basic.mass_radii[:-1] + 0.5 * self.basic.delta_mesh)
         if parameters.mesh.mass_coordinates:
             staggered_coordinates: npt.NDArray = (
-                self.get_staggered_coordinates_from_mass_coordinates(staggered_mass_coordinates))
+                self.get_staggered_spatial_coordinates_from_mass_coordinates(staggered_mass_coordinates))
         else:
             staggered_coordinates = staggered_mass_coordinates
         self.staggered: FixedMesh = FixedMesh(
@@ -269,7 +269,7 @@ class Mesh:
 
         return np.power(basic_mass_coordinates, 1.0/3.0)
 
-    def get_staggered_coordinates_from_mass_coordinates(self, staggered_mass_coordinates: npt.NDArray) -> npt.NDArray:
+    def get_staggered_spatial_coordinates_from_mass_coordinates(self, staggered_mass_coordinates: npt.NDArray) -> npt.NDArray:
         """Computes the staggered spatial coordinates from staggered mass coordinates.
 
         Args:

--- a/aragog/output.py
+++ b/aragog/output.py
@@ -232,7 +232,7 @@ class Output:
         volume = 4 * np.pi * (R_core**3) / 3
 
         # core density
-        rho = self.parameters.scalings.density * self.parameters.boundary_conditions.core_density
+        rho = self.parameters.scalings.density * self.parameters.mesh.core_density
 
         # core mass
         return rho * volume

--- a/aragog/output.py
+++ b/aragog/output.py
@@ -186,7 +186,12 @@ class Output:
     @property
     def melt_fraction_global(self) -> float:
         """Volume-averaged melt fraction"""
-        return self.evaluator.mesh.volume_average(self.melt_fraction_staggered[:, -1])
+        phase_to_use = self.evaluator._parameters.phase_mixed.phase
+        if phase_to_use == "mixed" or phase_to_use == "composite":
+            out = self.evaluator.mesh.volume_average(self.melt_fraction_staggered[:, -1])
+        else:
+            out = self.melt_fraction_staggered
+        return out
 
     @property
     def radii_km_basic(self) -> npt.NDArray:

--- a/aragog/output.py
+++ b/aragog/output.py
@@ -220,7 +220,7 @@ class Output:
         """Mass of each layer on staggered mesh"""
         return (
             # shells centred on staggered nodes
-            self.evaluator.mesh.effective_density
+            self.evaluator.mesh.staggered_effective_density
             * self.evaluator.mesh.basic.volume
             * self.parameters.scalings.density
             * np.power(self.parameters.scalings.radius, 3)

--- a/aragog/output.py
+++ b/aragog/output.py
@@ -199,6 +199,21 @@ class Output:
         return self.evaluator.mesh.basic.radii * self.parameters.scalings.radius * 1.0e-3
 
     @property
+    def radii_km_staggered(self) -> npt.NDArray:
+        """Radii of the staggered mesh in km"""
+        return self.evaluator.mesh.staggered.radii * self.parameters.scalings.radius * 1.0e-3
+
+    @property
+    def mass_radii_km_basic(self) -> npt.NDArray:
+        """Mass radii of the basic mesh in km"""
+        return self.evaluator.mesh.basic.mass_radii * self.parameters.scalings.radius * 1.0e-3
+
+    @property
+    def mass_radii_km_staggered(self) -> npt.NDArray:
+        """Mass radii of the staggered mesh in km"""
+        return self.evaluator.mesh.staggered.mass_radii * self.parameters.scalings.radius * 1.0e-3
+
+    @property
     def pressure_GPa_basic(self) -> npt.NDArray:
         """Pressure of the basic mesh in GPa"""
         return self.evaluator.mesh.basic_pressure * self.parameters.scalings.pressure * 1.0e-9

--- a/aragog/parser.py
+++ b/aragog/parser.py
@@ -143,7 +143,6 @@ class _BoundaryConditionsParameters:
     inner_boundary_value: float
     emissivity: float
     equilibrium_temperature: float
-    core_density: float
     core_heat_capacity: float
     scalings_: _ScalingsParameters = field(init=False)
 
@@ -155,7 +154,6 @@ class _BoundaryConditionsParameters:
         """
         self.scalings_ = scalings
         self.equilibrium_temperature /= self.scalings_.temperature
-        self.core_density /= self.scalings_.density
         self.core_heat_capacity /= self.scalings_.heat_capacity
         self._scale_inner_boundary_condition()
         self._scale_outer_boundary_condition()
@@ -268,11 +266,13 @@ class _MeshParameters:
     inner_radius: float
     number_of_nodes: int
     mixing_length_profile: str
+    core_density: float
     # Static pressure profile is derived from the Adams-Williamson equation of state.
     eos_method: int = 1 # 1: Adams-Williamson / 2: User defined
     surface_density: float = 4000
     gravitational_acceleration: float = 9.81
     adiabatic_bulk_modulus: float = 260e9
+    mass_coordinates: bool = False
     eos_file: str = ""
     scalings_: _ScalingsParameters = field(init=False)
 
@@ -285,6 +285,7 @@ class _MeshParameters:
         self.scalings_ = scalings
         self.outer_radius /= self.scalings_.radius
         self.inner_radius /= self.scalings_.radius
+        self.core_density /= self.scalings_.density
         self.surface_density /= self.scalings_.density
         self.gravitational_acceleration /= self.scalings_.gravitational_acceleration
         self.adiabatic_bulk_modulus /= self.scalings_.pressure


### PR DESCRIPTION
This work implements the mass coordinates for Aragog.

The mesh is built using the following steps:
- the basic coordinates are defined according to the settings (uniform spatial mesh)
- the eos is setup to get effective density and pressure
- the basic mass coordinates are computed
- the staggered mass coordinates are computed (cell centered)
- the staggered spatial coordinates are computed
- the routines to compute spatial derivates and mesh transformation are set up.

Mass coordinates are enabled through a config option. If not used mass coordinates are set equal to spatial coordinates.

I have checked that planet density and mass coordinates are correctly computed. Mass coordinates are always bigger than spatial coordinates which makes sense given that the density is decreasing from the core to the surface. At the surface, mass coordinate equals spatial coordinate.

I have run the abe mixed test with mass coordinates and see only minor effects (2 K). But for now I disabled mass coordinates in all the tests.