### PR TITLE
Add Zenodo tag for 1TPa data

### DIFF
--- a/aragog/__init__.py
+++ b/aragog/__init__.py
@@ -18,7 +18,7 @@
 
 from __future__ import annotations
 
-__version__: str = "0.2.8-alpha"
+__version__: str = "0.2.9-alpha"
 
 import importlib.resources
 import logging

--- a/aragog/data.py
+++ b/aragog/data.py
@@ -43,11 +43,12 @@ def get_zenodo_record(folder: str) -> str | None:
     zenodo_map = {
         '1TPa-dK09-elec-free/MgSiO3_Wolf_Bower_2018': '15877374',
         '1TPa-dK09-elec-free/MgSiO3_Wolf_Bower_2018_400GPa': '15877424',
-        '1TPa-dK09-elec-free/MgSiO3_Wolf_Bower_2018_1TPa': '17413837',
+        '1TPa-dK09-elec-free/MgSiO3_Wolf_Bower_2018_1TPa': '17417017',
         'Melting_curves/Monteux+600': '15728091',
         'Melting_curves/Monteux-600': '15728138',
         'Melting_curves/Wolf_Bower+2018': '15728072',
-    }    return zenodo_map.get(folder, None)
+    }
+    return zenodo_map.get(folder, None)
 
 def download_zenodo_folder(folder: str, data_dir: Path):
     """

--- a/aragog/data.py
+++ b/aragog/data.py
@@ -43,6 +43,7 @@ def get_zenodo_record(folder: str) -> str | None:
     zenodo_map = {
         '1TPa-dK09-elec-free/MgSiO3_Wolf_Bower_2018': '15877374',
         '1TPa-dK09-elec-free/MgSiO3_Wolf_Bower_2018_400GPa': '15877424',
+        '1TPa-dK09-elec-free/MgSiO3_Wolf_Bower_2018_1TPa': '17413837',
         'Melting_curves/Monteux+600': '15728091',
         'Melting_curves/Monteux-600': '15728138',
         'Melting_curves/Wolf_Bower+2018': '15728072',

--- a/aragog/data.py
+++ b/aragog/data.py
@@ -47,8 +47,7 @@ def get_zenodo_record(folder: str) -> str | None:
         'Melting_curves/Monteux+600': '15728091',
         'Melting_curves/Monteux-600': '15728138',
         'Melting_curves/Wolf_Bower+2018': '15728072',
-    }
-    return zenodo_map.get(folder, None)
+    }    return zenodo_map.get(folder, None)
 
 def download_zenodo_folder(folder: str, data_dir: Path):
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aragog"
-version = "0.2.8-alpha"
+version = "0.2.9-alpha"
 description = "1-D interior dynamics of rocky mantles that are solid, liquid, or mixed phase"
 authors = ["Dan J Bower <djbower@users.noreply.github.com>"]
 license = "GPL-3.0-or-later"

--- a/tests/test_phase.py
+++ b/tests/test_phase.py
@@ -37,7 +37,7 @@ pressure: npt.NDArray = np.atleast_2d([0, 135e9]).T
 
 def test_version():
     """Test version."""
-    assert __version__ == "0.2.8-alpha"
+    assert __version__ == "0.2.9-alpha"
 
 
 def test_liquid_constant_properties(helper):


### PR DESCRIPTION
This PR is for adding the Zenodo tag corresponding to the thermophysical properties of melt and solid up to 1TPa in a regular grid and update the version of Aragog.